### PR TITLE
Switched to Alpine Linux to reduce the container footprint

### DIFF
--- a/stop-russian-disinformation.Dockerfile
+++ b/stop-russian-disinformation.Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:latest
+FROM alpine:latest
 
-RUN apt update -y
-
-RUN apt upgrade -y
-
-RUN apt install curl -y
+RUN apk --no-cache update && \
+    apk --no-cache upgrade && \
+    apk --no-cache add curl
 
 RUN mkdir stop-russian-disinformation
 


### PR DESCRIPTION
Hello,
by switching the container base image to Alpine the script remains functional while reducing the container size from 130MB (Ubuntu) to 11MB (Alpine).